### PR TITLE
Pin alpine-based images to alpine 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Alpine Linux as a parent image
-FROM alpine:latest
+FROM alpine:3.6
 
 # Install bash, make, curl, git
 RUN apk update \


### PR DESCRIPTION
This is a temporary workaround for issues related to
gliderlabs/docker-alpine#363